### PR TITLE
v1.1.0

### DIFF
--- a/PriceSynchroniser.cs
+++ b/PriceSynchroniser.cs
@@ -20,12 +20,8 @@ namespace ContentWarningShop
             SyncPrices();
         }
 
-        internal static void SyncPrices()
+        private static void SyncPrices()
         {
-            if (SteamLobbyMetadataHandler.InLobby == false)
-            {
-                return;
-            }
             foreach (var item in Shop._items)
             {
                 SyncPrice(item);
@@ -34,15 +30,36 @@ namespace ContentWarningShop
 
         internal static void SyncPrice(Item item)
         {
-            var key = $"__{item.PersistentID}_price";
+            if (SteamLobbyMetadataHandler.InLobby == false)
+            {
+                return;
+            }
+            var key = $"{ShopApiPlugin.MOD_GUID}_item_{item.PersistentID}_price";
+            var changed = false;
             if (SteamLobbyMetadataHandler.IsHost)
             {
                 SteamMatchmaking.SetLobbyData(SteamLobbyMetadataHandler.CurrentLobby, key, $"{item.price}");
+                changed = true;
             }
             else
             {
                 var strVal = SteamMatchmaking.GetLobbyData(SteamLobbyMetadataHandler.CurrentLobby, key);
-                item.price = int.Parse(strVal);
+                var val = int.Parse(strVal);
+                changed = item.price != val;
+                item.price = val;
+            }
+            if (changed && ShopHandler.Instance != null)
+            {
+                if (ShopHandler.Instance.m_CategoryItemDic.ContainsKey(item.Category) == false)
+                {
+                    return;
+                }
+                var idx = ShopHandler.Instance.m_CategoryItemDic[item.Category].FindIndex(shopItem => shopItem.Item == item);
+                var newItem = new ShopItem(item);
+                ShopHandler.Instance.m_CategoryItemDic[item.Category][idx] = newItem;
+                ShopHandler.Instance.m_ItemsForSaleDictionary[item.id] = newItem;
+                // Does not actually call the RPC, this is the local effect
+                ShopHandler.Instance.RPCA_ClearCart();
             }
             Debug.Log($"Item price synchronised: {item.name} ({key}) = {item.price}");
         }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Use the `RegisterItem` method to register an `Item` to the shop. Ideally the ite
 Make sure to set the `persistentID`, `price`, `purchasable`, `Category`, and `icon` properties at the very least to ensure the item will show up correctly in the store.
 
 > [!NOTE]
-> Item prices are automatically synchronised between players on lobby join. The price set by the lobby's host will be used for the entire lobby. Once a lobby has been created, the price can not be changed.
+> Item prices are automatically synchronised between players on lobby join. The price set by the lobby's host will be used for the entire lobby. Once a lobby has been created, the price of a registered item can be updated via `UpdateItemPrice`.
 
 You can check if a custom item has been already registered via the `IsItemRegistered` method. The list of **all** registered custom items is also available via the `CustomItems` property.
 

--- a/Shop.cs
+++ b/Shop.cs
@@ -31,6 +31,11 @@ public static class Shop
     /// otherwise it may not be accurate.
     /// </remarks>
     public static byte MaxUsedEntryID => (byte)(byte.MaxValue - (byte)_customEntries.Count);
+    /// <summary>
+    /// Get if the player is the host of the current lobby. Will be false even if the player is not in a lobby.
+    /// </summary>
+    public static bool IsHost => SteamLobbyMetadataHandler.IsHost;
+    public static bool InLobby => SteamLobbyMetadataHandler.InLobby;
 
     static Shop()
     {
@@ -65,7 +70,7 @@ public static class Shop
         }
         _items.Add(item);
         SingletonAsset<ItemDatabase>.Instance.AddRuntimeEntry(item);
-        Debug.LogWarning($"Registered custom item: {item.displayName} ({item.persistentID}) [{Assembly.GetCallingAssembly().GetSimpleName()}].");
+        Debug.Log($"Registered custom item: {item.displayName} ({item.persistentID}) [{Assembly.GetCallingAssembly().GetSimpleName()}].");
     }
 
     /// <summary>

--- a/Shop.cs
+++ b/Shop.cs
@@ -63,6 +63,10 @@ public static class Shop
             Debug.LogWarning($"Item {item.displayName} ({item.persistentID}) already registered.");
             return;
         }
+        if (item.Category == ShopItemCategory.Invalid)
+        {
+            throw new Exception($"Item {item.displayName} ({item.persistentID}) shop category is set to {nameof(ShopItemCategory.Invalid)}.");
+        }
         _items.Add(item);
         SingletonAsset<ItemDatabase>.Instance.AddRuntimeEntry(item);
         Debug.Log($"Registered custom item: {item.displayName} ({item.persistentID}) [{Assembly.GetCallingAssembly().GetSimpleName()}].");

--- a/Shop.cs
+++ b/Shop.cs
@@ -31,11 +31,6 @@ public static class Shop
     /// otherwise it may not be accurate.
     /// </remarks>
     public static byte MaxUsedEntryID => (byte)(byte.MaxValue - (byte)_customEntries.Count);
-    /// <summary>
-    /// Get if the player is the host of the current lobby. Will be false even if the player is not in a lobby.
-    /// </summary>
-    public static bool IsHost => SteamLobbyMetadataHandler.IsHost;
-    public static bool InLobby => SteamLobbyMetadataHandler.InLobby;
 
     static Shop()
     {

--- a/Shop.cs
+++ b/Shop.cs
@@ -99,6 +99,35 @@ public static class Shop
     }
 
     /// <summary>
+    /// Updates the given item's price and synchronises it with other players.
+    /// </summary>
+    /// <remarks>
+    /// Setting lobby metadata is only allowed if the current player is the lobby's owner. Use the return value to determine if the set was possible.
+    /// </remarks>
+    /// <param name="item"></param>
+    /// <param name="price"></param>
+    /// <returns>
+    /// <see langword="true"/> if updating the price was successful (player is not in a lobby OR the owner of the current lobby).
+    /// <see langword="false"/> if the player is in a lobby but is not the lobby's host.
+    /// </returns>
+    public static bool UpdateItemPrice(Item item, int price)
+    {
+        if (IsItemRegistered(item) == false)
+        {
+            Debug.LogWarning($"Item {item.name} ({item.persistentID}) is not registered with {ShopApiPlugin.MOD_NAME}");
+            return false;
+        }
+        if (SteamLobbyMetadataHandler.IsHost == false && SteamLobbyMetadataHandler.InLobby)
+        {
+            Debug.LogError($"Tried updating item price when not the lobby host; this is not allowed.");
+            return false;
+        }
+        item.price = price;
+        PriceSynchroniser.SyncPrice(item);
+        return true;
+    }
+
+    /// <summary>
     /// Returns the list of item data data entries derived from <see cref="ItemDataEntry"/> in the given assembly.
     /// </summary>
     /// <param name="assembly"></param>

--- a/SteamLobbyMetadataHandler.cs
+++ b/SteamLobbyMetadataHandler.cs
@@ -1,0 +1,72 @@
+﻿using Steamworks;
+using UnityEngine;
+
+namespace ContentWarningShop
+{
+    internal static class SteamLobbyMetadataHandler
+    {
+        private static Callback<LobbyChatUpdate_t> cb_onLobbyStatusUpdate;
+        private static Callback<LobbyCreated_t> cb_onLobbyCreated;
+        private static Callback<LobbyEnter_t> cb_onLobbyEntered;
+        private static Callback<LobbyDataUpdate_t> cb_onLobbyDataUpdate;
+        //
+        internal static event Action? OnLobbyJoined;
+        internal static event Action? OnLobbyLeft;
+        internal static event Action? OnLobbyDataUpdate;
+
+        internal static CSteamID CurrentLobby;
+        internal static bool InLobby => CurrentLobby != default;
+        internal static bool IsHost => InLobby && SteamMatchmaking.GetLobbyOwner(CurrentLobby) == SteamUser.GetSteamID();
+
+        static SteamLobbyMetadataHandler()
+        {
+            cb_onLobbyStatusUpdate = Callback<LobbyChatUpdate_t>.Create(Steam_LobbyLeft);
+            cb_onLobbyCreated = Callback<LobbyCreated_t>.Create(Steam_LobbyCreated);
+            cb_onLobbyEntered = Callback<LobbyEnter_t>.Create(Steam_LobbyEntered);
+            cb_onLobbyDataUpdate = Callback<LobbyDataUpdate_t>.Create(Steam_LobbyDataUpdated);
+        }
+
+        private static void Steam_LobbyCreated(LobbyCreated_t e)
+        {
+            if (e.m_eResult == EResult.k_EResultOK)
+            {
+                CurrentLobby = new CSteamID(e.m_ulSteamIDLobby);
+                OnLobbyJoined?.Invoke();
+            }
+        }
+
+        private static void Steam_LobbyEntered(LobbyEnter_t e)
+        {
+            // If we created the lobby, don't call the event again. Otherwise _currentLobby will be default by now
+            if (CurrentLobby == default)
+            {
+                CurrentLobby = new CSteamID(e.m_ulSteamIDLobby);
+                OnLobbyJoined?.Invoke();
+            }
+        }
+
+        private static void Steam_LobbyLeft(LobbyChatUpdate_t e)
+        {
+            var user = new CSteamID(e.m_ulSteamIDUserChanged);
+            if (user != SteamUser.GetSteamID())
+            {
+                return;
+            }
+            if ((EChatMemberStateChange)e.m_rgfChatMemberStateChange != EChatMemberStateChange.k_EChatMemberStateChangeEntered)
+            {
+                // Lobby left
+                CurrentLobby = default;
+                OnLobbyLeft?.Invoke();
+            }
+        }
+
+        private static void Steam_LobbyDataUpdated(LobbyDataUpdate_t e)
+        {
+            if (InLobby == false || e.m_ulSteamIDLobby != e.m_ulSteamIDMember)
+            {
+                return;
+            }
+            OnLobbyDataUpdate?.Invoke();
+        }
+    }
+}

--- a/SteamLobbyMetadataHandler.cs
+++ b/SteamLobbyMetadataHandler.cs
@@ -5,22 +5,20 @@ namespace ContentWarningShop
 {
     internal static class SteamLobbyMetadataHandler
     {
-        private static Callback<LobbyChatUpdate_t> cb_onLobbyStatusUpdate;
         private static Callback<LobbyCreated_t> cb_onLobbyCreated;
         private static Callback<LobbyEnter_t> cb_onLobbyEntered;
         private static Callback<LobbyDataUpdate_t> cb_onLobbyDataUpdate;
         //
         internal static event Action? OnLobbyJoined;
-        internal static event Action? OnLobbyLeft;
         internal static event Action? OnLobbyDataUpdate;
 
-        internal static CSteamID CurrentLobby;
-        internal static bool InLobby => CurrentLobby != default;
-        internal static bool IsHost => InLobby && SteamMatchmaking.GetLobbyOwner(CurrentLobby) == SteamUser.GetSteamID();
+        internal static CSteamID CurrentLobby = CSteamID.Nil;
+        // GetLobbyOwner returns nil if the current lobby is invalid / we are not in it
+        internal static bool InLobby => SteamMatchmaking.GetLobbyOwner(CurrentLobby) != CSteamID.Nil;
+        internal static bool IsHost => SteamMatchmaking.GetLobbyOwner(CurrentLobby) == SteamUser.GetSteamID();
 
         static SteamLobbyMetadataHandler()
         {
-            cb_onLobbyStatusUpdate = Callback<LobbyChatUpdate_t>.Create(Steam_LobbyLeft);
             cb_onLobbyCreated = Callback<LobbyCreated_t>.Create(Steam_LobbyCreated);
             cb_onLobbyEntered = Callback<LobbyEnter_t>.Create(Steam_LobbyEntered);
             cb_onLobbyDataUpdate = Callback<LobbyDataUpdate_t>.Create(Steam_LobbyDataUpdated);
@@ -38,31 +36,16 @@ namespace ContentWarningShop
         private static void Steam_LobbyEntered(LobbyEnter_t e)
         {
             // If we created the lobby, don't call the event again. Otherwise _currentLobby will be default by now
-            if (CurrentLobby == default)
+            if (InLobby == false)
             {
                 CurrentLobby = new CSteamID(e.m_ulSteamIDLobby);
                 OnLobbyJoined?.Invoke();
             }
         }
 
-        private static void Steam_LobbyLeft(LobbyChatUpdate_t e)
-        {
-            var user = new CSteamID(e.m_ulSteamIDUserChanged);
-            if (user != SteamUser.GetSteamID())
-            {
-                return;
-            }
-            if ((EChatMemberStateChange)e.m_rgfChatMemberStateChange != EChatMemberStateChange.k_EChatMemberStateChangeEntered)
-            {
-                // Lobby left
-                CurrentLobby = default;
-                OnLobbyLeft?.Invoke();
-            }
-        }
-
         private static void Steam_LobbyDataUpdated(LobbyDataUpdate_t e)
         {
-            if (InLobby == false || e.m_ulSteamIDLobby != e.m_ulSteamIDMember)
+            if (e.m_ulSteamIDLobby != e.m_ulSteamIDMember)
             {
                 return;
             }

--- a/SynchronisedMetadata.cs
+++ b/SynchronisedMetadata.cs
@@ -105,7 +105,7 @@ namespace ContentWarningShop
         /// Checks if assigning a new value is possible from this client.
         /// </summary>
         /// <remarks>
-        /// If the client is not in a lobby, this method returns true and the set value is treated as initialisation before joining one.
+        /// If the client is not in a lobby, returns true, otherwise checks if the player is the lobby's host.
         /// </remarks>
         /// <returns></returns>
         public bool CanSet()
@@ -116,6 +116,9 @@ namespace ContentWarningShop
         /// <summary>
         /// Sets the entry to a new value.
         /// </summary>
+        /// <remarks>
+        /// Setting a new value is only possible by the host of the lobby, or if the player in not in a lobby.
+        /// </remarks>
         /// <param name="value"></param>
         /// <returns>
         /// <see langword="true"/> if assigning the new value from this client was possible, <see langword="false"/> if not.

--- a/publish/thunderstore/CHANGELOG.md
+++ b/publish/thunderstore/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.3
+- Minor patch that mainly affects the internals. The only outward change is removal of an unintended and difficult to access static property from SynchronisedMetadata class:
+```csharp
+public static bool InLobby -> public bool InLobby
+public static bool IsHost -> public bool IsHost
+```
+  - These are still available as instance fields, but have been removed from the static class.
+
 ## 1.0.2
 - Fix tooltips not being parsed correctly when using the fallback
 

--- a/publish/thunderstore/CHANGELOG.md
+++ b/publish/thunderstore/CHANGELOG.md
@@ -3,13 +3,19 @@
 All notable changes will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.0.3
-- Minor patch that mainly affects the internals. The only outward change is removal of an unintended and difficult to access static property from SynchronisedMetadata class:
+## 1.1.0
+- Fixed an issue where all synchronisation broke after leaving a lobby and joining a new one in the same session.
+
+- Added `UpdateItemPrice` method. Use this to update the price of items anytime during a game, and they'll be synchronised between players.
+	- This will also reload the store, so the current cart gets reset.
+
+- Removed mistakenly marked `static` fields from `SynchronisedMetadata`. These are now instance fields:
 ```csharp
 public static bool InLobby -> public bool InLobby
 public static bool IsHost -> public bool IsHost
 ```
-  - These are still available as instance fields, but have been removed from the static class.
+
+- Reworked `SynchronisedMetadata` internals
 
 ## 1.0.2
 - Fix tooltips not being parsed correctly when using the fallback

--- a/publish/thunderstore/manifest.json
+++ b/publish/thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "ShopAPI",
-    "version_number": "1.0.3",
+    "version_number": "1.1.0",
     "website_url": "https://github.com/Xerren09/ContentWarningShopAPI",
     "description": "Exposes an easy-to-use API to add custom items to the in-game shop.",
     "dependencies": [

--- a/publish/thunderstore/manifest.json
+++ b/publish/thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "ShopAPI",
-    "version_number": "1.0.2",
+    "version_number": "1.0.3",
     "website_url": "https://github.com/Xerren09/ContentWarningShopAPI",
     "description": "Exposes an easy-to-use API to add custom items to the in-game shop.",
     "dependencies": [


### PR DESCRIPTION
Fixed an issue where all synchronisation broke after leaving a lobby and joining a new one in the same session.

Added `UpdateItemPrice` method. Use this to update the price of items anytime during a game, and they'll be synchronised between players.
	- This will also reload the store, so the current cart gets reset.

Removed mistakenly marked `static` fields from `SynchronisedMetadata<T>`. These are now instance fields:
```csharp
public static bool InLobby -> public bool InLobby
public static bool IsHost -> public bool IsHost
```
